### PR TITLE
Problem: non Rust idiomatic error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block"
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "cnf"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bindgen",
  "glob",
@@ -134,9 +134,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -244,9 +244,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.4"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -254,18 +254,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -301,9 +301,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "cnf"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 glob = "0.3.1"
-libc = "0.2.140"
+libc = "0.2.149"
 tr = "0.1.7"
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = "0.68.1"
 
 [profile.release]
 lto = true

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -9,8 +9,8 @@ pub struct Repo {
     pub name: String,
 }
 
-pub fn repo_enabled(path: &PathBuf) -> Result<Repo, String> {
-    let lines = read_lines(&path).map_err(stringify)?;
+pub fn repo_enabled(path: &PathBuf) -> Result<Repo, std::io::Error> {
+    let lines = read_lines(&path)?;
     let mut name = String::from("N/A");
 
     for line in lines {
@@ -42,11 +42,4 @@ where
 {
     let file = File::open(filename)?;
     Ok(io::BufReader::new(file).lines())
-}
-
-fn stringify<T>(e: T) -> String
-where
-    T: std::fmt::Display,
-{
-    return format!("{}", e);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,7 @@
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
 extern crate glob;
-extern crate libc;
 #[macro_use]
 extern crate tr;
 
-use std::env;
-use std::ffi::CStr;
-use std::ffi::CString;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::exit;
@@ -19,8 +9,14 @@ use std::result::Result;
 use std::vec::Vec;
 
 mod ini;
+mod pool;
 
 const REPO_GLOB: &str = "/etc/zypp/repos.d/*.repo";
+
+pub struct SolvInput {
+    name: String,
+    path: PathBuf,
+}
 
 fn main() {
     // use the tr_init macro to tell gettext where to look for translations
@@ -56,7 +52,7 @@ fn main() {
 fn search_solv(term: &str) -> Result<(), ErrorKind> {
     let repos = load_repos()?;
 
-    let pool = SPool::new(&repos).map_err(kindify)?;
+    let pool = pool::SPool::new(&repos)?;
     let results = pool.search(&term);
 
     if results.len() == 0 {
@@ -102,11 +98,6 @@ fn search_solv(term: &str) -> Result<(), ErrorKind> {
     Ok(())
 }
 
-struct SolvInput {
-    name: String,
-    path: PathBuf,
-}
-
 fn load_repos() -> Result<Vec<SolvInput>, ErrorKind<'static>> {
     let mut repos: Vec<SolvInput> = Vec::new();
     for repo in glob::glob(REPO_GLOB)? {
@@ -125,117 +116,6 @@ fn load_repos() -> Result<Vec<SolvInput>, ErrorKind<'static>> {
         }
     }
     Ok(repos)
-}
-
-struct SPool {
-    pool: *mut Pool,
-}
-
-impl SPool {
-    fn new(repos: &Vec<SolvInput>) -> Result<SPool, String> {
-        let pool: *mut Pool = unsafe {
-            let ptr = pool_create();
-            if ptr.is_null() {
-                return Err(String::from("pool_create returned NULL"));
-            }
-            ptr
-        };
-
-        for input in repos {
-            let cname = CString::new(input.name.to_string()).map_err(
-                |_e: std::ffi::NulError| -> String { String::from("input.name is null") },
-            )?;
-            let csolv = CString::new(input.path.display().to_string()).map_err(
-                |_e: std::ffi::NulError| -> String { String::from("input.path is null") },
-            )?;
-            let repo: *mut Repo = unsafe { repo_create(pool, cname.into_raw()) };
-            if repo.is_null() {
-                return Err(format!("pool_create({}) returned NULL", input.name));
-            }
-
-            unsafe {
-                let fp = fopen(csolv.into_raw(), CString::new("r").unwrap().into_raw());
-                if fp.is_null() {
-                    return Err(format!("can't open {}", input.path.display()));
-                }
-                let r = repo_add_solv(repo, fp, 0);
-                fclose(fp);
-                if r != 0 {
-                    return Err(format!("repo_add_solv failed on {}", input.path.display()));
-                }
-            }
-        }
-
-        Ok(SPool { pool })
-    }
-
-    fn search(&self, term: &str) -> Vec<SearchResult> {
-        let cterm = CString::new(term).unwrap();
-        // https://stackoverflow.com/questions/38995701/how-do-i-pass-a-closure-through-raw-pointers-as-an-argument-to-a-c-function/38997480#38997480
-        let mut results: Vec<SearchResult> = Vec::new();
-        let mut append = |repo: String, package: String, path: String| {
-            if path != "/usr/bin" && path != "/usr/sbin" {
-                return;
-            }
-            results.push(SearchResult {
-                Repo: repo.clone(),
-                Package: package,
-                Path: path,
-            });
-        };
-        let mut trait_obj: &mut dyn FnMut(String, String, String) = &mut append;
-        let trait_obj_ref = &mut trait_obj;
-
-        unsafe {
-            pool_search(
-                self.pool,
-                0,
-                solv_knownid_SOLVABLE_FILELIST as i32,
-                cterm.as_ptr(),
-                SEARCH_STRING as i32,
-                Some(callback),
-                trait_obj_ref as *mut _ as *mut libc::c_void,
-            );
-        }
-        results
-    }
-}
-
-struct SearchResult {
-    Repo: String,
-    Package: String,
-    Path: String,
-}
-
-impl Drop for SPool {
-    fn drop(&mut self) {
-        unsafe { pool_free(self.pool) };
-    }
-}
-
-unsafe extern "C" fn callback(
-    cbdata: *mut libc::c_void,
-    s: *mut s_Solvable,
-    data: *mut s_Repodata,
-    _key: *mut s_Repokey,
-    kv: *mut s_KeyValue,
-) -> i32 {
-    // TODO: handle NULL and error here gracefully
-    let repo = CStr::from_ptr((*(*s).repo).name).to_str().unwrap();
-    let name = CStr::from_ptr(solvable_lookup_str(s, solv_knownid_SOLVABLE_NAME as i32))
-        .to_str()
-        .unwrap();
-    let path = CStr::from_ptr(repodata_dir2str(
-        data,
-        (*kv).id,
-        0 as *const std::os::raw::c_char,
-    ))
-    .to_str()
-    .unwrap();
-
-    let append: &mut &mut dyn FnMut(String, String, String) = &mut *(cbdata as *mut _);
-    append(String::from(repo), String::from(name), String::from(path));
-    0
 }
 
 // ErrorKind encodes all errors which can happen in command not found handler
@@ -285,7 +165,9 @@ impl From<std::io::Error> for ErrorKind<'_> {
     }
 }
 
-//TODO: to be removed once all errors will get converted to ErrorKind enum
-fn kindify(s: String) -> ErrorKind<'static> {
-    return ErrorKind::String(s);
+// TODO: drop this From implementation, the proper errors from src/pool.rs may be used instead
+impl From<String> for ErrorKind<'_> {
+    fn from(value: String) -> Self {
+        return ErrorKind::String(value);
+    }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,124 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+extern crate libc;
+
+use crate::SolvInput;
+use std::env;
+use std::ffi::CStr;
+use std::ffi::CString;
+
+pub struct SPool {
+    pool: *mut Pool,
+}
+
+pub struct SearchResult {
+    pub Repo: String,
+    pub Package: String,
+    pub Path: String,
+}
+
+impl SPool {
+    pub fn new(repos: &Vec<SolvInput>) -> Result<SPool, String> {
+        let pool: *mut Pool = unsafe {
+            let ptr = pool_create();
+            if ptr.is_null() {
+                return Err(String::from("pool_create returned NULL"));
+            }
+            ptr
+        };
+
+        for input in repos {
+            let cname = CString::new(input.name.to_string()).map_err(
+                |_e: std::ffi::NulError| -> String { String::from("input.name is null") },
+            )?;
+            let csolv = CString::new(input.path.display().to_string()).map_err(
+                |_e: std::ffi::NulError| -> String { String::from("input.path is null") },
+            )?;
+            let repo: *mut Repo = unsafe { repo_create(pool, cname.into_raw()) };
+            if repo.is_null() {
+                return Err(format!("pool_create({}) returned NULL", input.name));
+            }
+
+            unsafe {
+                let fp = fopen(csolv.into_raw(), CString::new("r").unwrap().into_raw());
+                if fp.is_null() {
+                    return Err(format!("can't open {}", input.path.display()));
+                }
+                let r = repo_add_solv(repo, fp, 0);
+                fclose(fp);
+                if r != 0 {
+                    return Err(format!("repo_add_solv failed on {}", input.path.display()));
+                }
+            }
+        }
+
+        Ok(SPool { pool })
+    }
+
+    pub fn search(&self, term: &str) -> Vec<SearchResult> {
+        let cterm = CString::new(term).unwrap();
+        // https://stackoverflow.com/questions/38995701/how-do-i-pass-a-closure-through-raw-pointers-as-an-argument-to-a-c-function/38997480#38997480
+        let mut results: Vec<SearchResult> = Vec::new();
+        let mut append = |repo: String, package: String, path: String| {
+            if path != "/usr/bin" && path != "/usr/sbin" {
+                return;
+            }
+            results.push(SearchResult {
+                Repo: repo.clone(),
+                Package: package,
+                Path: path,
+            });
+        };
+        let mut trait_obj: &mut dyn FnMut(String, String, String) = &mut append;
+        let trait_obj_ref = &mut trait_obj;
+
+        unsafe {
+            pool_search(
+                self.pool,
+                0,
+                solv_knownid_SOLVABLE_FILELIST as i32,
+                cterm.as_ptr(),
+                SEARCH_STRING as i32,
+                Some(callback),
+                trait_obj_ref as *mut _ as *mut libc::c_void,
+            );
+        }
+        results
+    }
+}
+
+impl Drop for SPool {
+    fn drop(&mut self) {
+        unsafe { pool_free(self.pool) };
+    }
+}
+
+unsafe extern "C" fn callback(
+    cbdata: *mut libc::c_void,
+    s: *mut s_Solvable,
+    data: *mut s_Repodata,
+    _key: *mut s_Repokey,
+    kv: *mut s_KeyValue,
+) -> i32 {
+    // TODO: handle NULL and error here gracefully
+    let repo = CStr::from_ptr((*(*s).repo).name).to_str().unwrap();
+    let name = CStr::from_ptr(solvable_lookup_str(s, solv_knownid_SOLVABLE_NAME as i32))
+        .to_str()
+        .unwrap();
+    let path = CStr::from_ptr(repodata_dir2str(
+        data,
+        (*kv).id,
+        0 as *const std::os::raw::c_char,
+    ))
+    .to_str()
+    .unwrap();
+
+    let append: &mut &mut dyn FnMut(String, String, String) = &mut *(cbdata as *mut _);
+    append(String::from(repo), String::from(name), String::from(path));
+    0
+}

--- a/test/test.bats
+++ b/test/test.bats
@@ -22,6 +22,10 @@ setup() {
     assert_output --partial "Absolute path to 'sysctl' is '/usr/sbin/sysctl', so running it may require superuser privileges (eg. root)."
 }
 
+@test "root: not installed xnake" {
+    run -127 root.sh '/usr/bin/cnf' 'xnake'
+    assert_output --partial " xnake: command not found"
+}
 
 @test "root: not installed make" {
     run root.sh '/usr/bin/cnf' 'make'


### PR DESCRIPTION
Solution: while passing String is good enough, idiomatic Rust code
prefer passing an enum. It has an advantage that it encodes all errors
states of the code in a single place.

Add ErrorKind enum with CommandNotFound and String variants and
print_error function, which prints the human readable error on console.

Add an integration test for CommandNotFound error.
