### PR TITLE
Translations update from openSUSE Weblate

### DIFF
--- a/i18n/po/sl/cnf.po
+++ b/i18n/po/sl/cnf.po
@@ -8,51 +8,57 @@ msgstr ""
 "Project-Id-Version: cnf 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-05-29 11:17+0000\n"
-"PO-Revision-Date: 2005-08-24 17:37+0200\n"
-"Last-Translator: Janez Krek <janez.krek@euroteh.si>\n"
-"Language-Team: Slovenščina <sl@li.org>\n"
+"PO-Revision-Date: 2025-08-11 16:59+0000\n"
+"Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
+"Language-Team: Slovenian <https://l10n.opensuse.org/projects/cnf/main/sl/>\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: KBabel 1.3.1\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
+"X-Generator: Weblate 5.12.2\n"
 
 #: src/main.rs:47
 msgid ""
 "Absolute path to '{}' is '{}'. Please check your $PATH variable to see "
 "whether it contains the mentioned path."
 msgstr ""
+"Absolutna pot do »{}« je »{}«. Preverite, ali okoljska spremenljivka $PATH "
+"vsebuje omenjeno pot."
 
 #: src/main.rs:53
 msgid ""
 "Absolute path to '{}' is '{}', so running it may require superuser "
 "privileges (eg. root)."
 msgstr ""
+"Absolutna pot do »{}« je »{}« in zagon morda zahteva pravice skrbnika (npr. "
+"root)."
 
 #: src/main.rs:82
 msgid "<selected_package>"
-msgstr ""
+msgstr "<izbrani_paket>"
 
 #: src/main.rs:89
 msgid "The program '{}' can be found in the following package:"
 msgid_plural "The program '{}' can be found in following packages:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "Program »{}« lahko najdete v naslednjem paketu:"
+msgstr[1] "Program »{}« lahko najdete v naslednjih paketih:"
+msgstr[2] "Program »{}« lahko najdete v naslednjih paketih:"
+msgstr[3] "Program »{}« lahko najdete v naslednjih paketih:"
 
 #: src/main.rs:99
 msgid "  * {} [ path: {}/{}, repository: {} ]"
-msgstr ""
+msgstr "  * {} [ pot: {}/{}, vir: {} ]"
 
 #: src/main.rs:111
 msgid ""
 "Try installing with:\n"
 "   "
 msgstr ""
+"Poskusite ga namestiti z:\n"
+"   "
 
 #: src/main.rs:142
 msgid "command not found"
-msgstr "Gostitelja %s ni."
+msgstr "ukaz ni bil najden"


### PR DESCRIPTION
Translations update from [openSUSE Weblate](https://l10n.opensuse.org) for [cnf/cnf main](https://l10n.opensuse.org/projects/cnf/main/).



Current translation status:

![Weblate translation status](https://l10n.opensuse.org/widget/cnf/main/horizontal-auto.svg)