### PR TITLE
(fix): Duplicate entries shown (GH #26)

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -38,6 +38,12 @@ jobs:
         env:
           RUSTFLAGS: "-Dwarnings"
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
+
       - uses: docker/setup-buildx-action@v2
 
       -

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ name = "cnf"
 version = "0.7.0"
 dependencies = [
  "bindgen",
+ "cc",
  "glob",
  "libc",
  "tr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,17 +13,15 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -31,14 +29,13 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "block"
@@ -48,9 +45,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
@@ -66,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clang-sys"
@@ -99,16 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "errno"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "gettext-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,17 +117,17 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "home"
-version = "0.5.9"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
- "windows-sys 0.52.0",
+ "either",
 ]
 
 [[package]]
@@ -150,32 +137,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "locale_config"
@@ -192,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "malloc_buf"
@@ -207,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -257,22 +232,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -280,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -327,22 +290,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
-]
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "shlex"
@@ -352,9 +302,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -363,18 +313,17 @@ dependencies = [
 
 [[package]]
 name = "temp-dir"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
+checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
 
 [[package]]
 name = "tr"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a592877f7cb2e5a6327b8c908fa6d51098482b1c87d478abdd783e61218f8151"
+checksum = "79d30c7e79732253d80e9d619007002c8f3a362b0816e37340af648d4e2c6092"
 dependencies = [
  "gettext-rs",
- "lazy_static",
 ]
 
 [[package]]
@@ -382,18 +331,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "winapi"
@@ -418,29 +355,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -453,48 +379,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tr = "0.1.7"
 
 [build-dependencies]
 cc = "1"
-bindgen = "~0.68.1"
+bindgen = "0.72.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ libc = "0.2.149"
 tr = "0.1.7"
 
 [build-dependencies]
+cc = "1"
 bindgen = "~0.68.1"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The testing itself is wrapped in [bats](https://github.com/bats-core/bats-core) 
 > 6 tests, 0 failures
 > ```
 
-Every test can be executed on a command line. The `root.sh` wrapper mounts the binary to `/usr/bin/cnf` and mounts the `libsolv.so.1` if running on ubuntu-amd64 or if shared library is in `test/libsolv.so.1`. This is done in order to solve the packaging difference of a libsolv between openSUSE and Ubuntu.
+Every test can be executed on a command line. The `root.sh` wrapper mounts the
+binary to `/usr/bin/cnf` and bash/fish integrations.
 
 ```.sh
 ./root.sh /usr/bin/cnf rpm
@@ -105,7 +106,9 @@ Every test can be executed on a command line. The `root.sh` wrapper mounts the b
 
 ## **PowerShell users**
 
-As `cnf` does not integrate with PowerShell by default, please read the issue comment https://github.com/openSUSE/cnf/issues/8#issuecomment-1854638267 to learn how to configure your system properly:
+As `cnf` does not integrate with PowerShell by default, please read the issue
+comment https://github.com/openSUSE/cnf/issues/8#issuecomment-1854638267 to
+learn how to configure your system properly:
 
 <blockQuote>
 

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .allowlist_type(".*Pool")
         .allowlist_type("solv_knownid.*")
         .allowlist_var("SEARCH_STRING")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.77.0"
-components = ["rustfmt", "clippy"]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -2,7 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(unnecessary_transmutes)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::ptr_offset_with_cast)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 

--- a/src/solv_shim.c
+++ b/src/solv_shim.c
@@ -1,0 +1,7 @@
+#include <solv/pool.h>
+#include <solv/repo.h>
+#include <solv/solvable.h>
+
+int cnf_pool_installable(Pool *pool, Solvable *s) {
+    return pool_installable(pool, s);
+}

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,6 +8,8 @@ ADD --chown=65532:65532 nonroot /home/nonroot/whoami
 RUN zypper refresh
 # minimize number of packages installed
 RUN zypper --non-interactive addlock busybox dbus diffutils pam-config perl-base pkgconf-m4 systemd groff man
-RUN zypper --non-interactive install --no-recommends zsh fish
+RUN zypper --non-interactive install --no-recommends zsh fish libsolv1
+RUN zypper --non-interactive addrepo https://download.opensuse.org/repositories/GNOME:/Next/openSUSE_Factory/GNOME:Next.repo
+RUN zypper --gpg-auto-import-keys refresh GNOME_Next
 
 WORKDIR /src

--- a/test/root.sh
+++ b/test/root.sh
@@ -3,8 +3,8 @@
 set -e
 
 #
-# Runs cnf binary inside (openSUSE) container. Mounts the cnf, bash integration and
-# libsolv.so.1 into container ensuring the tool can run there.
+# Runs cnf binary inside (openSUSE) container. Mounts the cnf, bash and fish
+# integration and into container ensuring the tool can run there.
 #
 # To be executed manually or via bats test.bats
 #
@@ -15,27 +15,16 @@ BASH_CNF=$(readlink -f "${PROJECT_DIR}/command_not_found.bash")
 ZSH_CNF=$(readlink -f "${PROJECT_DIR}/command_not_found.zsh")
 
 USER="root"
-if [[ "${0}" =~ "nonroot.sh" ]]; then
+if [[ "${0}" =~ nonroot.sh ]]; then
     USER="nonroot"
 fi
 
 VOLUMES=()
-VOLUMES[0]="--volume "${CNF_SRC}":/usr/bin/cnf:ro"
+VOLUMES[0]="--volume ${CNF_SRC}:/usr/bin/cnf:ro"
 # needed for fish shell: boo#1215428
-VOLUMES[1]="--volume "${CNF_SRC}":/usr/bin/command-not-found:ro"
-VOLUMES[2]="--volume "${BASH_CNF}":/usr/etc/bash_command_not_found:ro"
-VOLUMES[3]="--volume "${ZSH_CNF}":/usr/etc/zsh_command_not_found:ro"
-
-# github action uses the ubuntu-latest with libsolv-dev, which is a shared library
-# openSUSE distributes libsolv only as static library on the other hand
-# so if running the script on ubuntu-latest, mount the shared library into openSUSE container
-# to make it run there
-if [[ -f /usr/lib/x86_64-linux-gnu/libsolv.so.1 ]]; then
-    VOLUMES[4]="--volume /usr/lib/x86_64-linux-gnu/libsolv.so.1:/usr/lib64/libsolv.so.1:ro"
-elif [[ -f "${PROJECT_DIR}/test/libsolv.so.1" ]]; then
-    # mount the libsolv.so.1 if it is in test/ directory: this supports the development
-    VOLUMES[4]="--volume "${PROJECT_DIR}/test/libsolv.so.1":/usr/lib64/libsolv.so.1:ro"
-fi
+VOLUMES[1]="--volume ${CNF_SRC}:/usr/bin/command-not-found:ro"
+VOLUMES[2]="--volume ${BASH_CNF}:/usr/etc/bash_command_not_found:ro"
+VOLUMES[3]="--volume ${ZSH_CNF}:/usr/etc/zsh_command_not_found:ro"
 
 docker \
     run \

--- a/test/test.bats
+++ b/test/test.bats
@@ -67,4 +67,10 @@ setup() {
     assert_output --partial "The program 'cmake' can be found in following packages:"
 }
 
+@test "issue26: do not list not installable files" {
+    run root.sh '/usr/bin/cnf' 'fractal'
+    pkg_lines="$(printf '%s\n' "$output" | grep -c -E '^  \*')"
+    [ "$pkg_lines" -eq 2 ]
+}
+
 # TODO: install i18n

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,5 +1,9 @@
+#pragma once
+
 #include <solv/pool.h>
 #include <solv/repo.h>
 #include <solv/repo_solv.h>
 #include <solv/dataiterator.h>
 #include <solv/knownid.h>
+
+int cnf_pool_installable(Pool *pool, Solvable *s);


### PR DESCRIPTION
The pool_search results are checked if the given solvable is installable
or not. This work reuses `static inline int pool_installable(const Pool
*pool, Solvable *s)` helper from `libsolv/src/repo.h` which is
reexported to Rust as `cnf_pool_installable` in a shim. The
`pool_setarch` is called after `pool_create` ensuring filtering works.

The integration tests recognizes the fact openSUSE ships with `libsolv.so.1`
now removing the special cases in helpers.

Drop `rust-toolchain.toml` - given the fast pace of a Rust ecosystem, it's better to maintain the SLE/Leap variant in a separate fork rather than trying to use older rust compiler, which happen to be in a SLE/Leap.
