### PR TITLE
(refactor): unit test, less unsafe, callback smaller, lint in pool.rs

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -38,6 +38,10 @@ jobs:
         env:
           RUSTFLAGS: "-Dwarnings"
 
+      -
+        name: unit tests
+        run: cargo test
+
       - name: Install cargo-audit
         run: cargo install cargo-audit
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "cnf"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cnf"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.77.0"
 


### PR DESCRIPTION
 * add unit test for ini.rs
 * refactor the code to accept a std::io::BufRead so can be actually
   unit tested
 * limit the number of unsafe blocks
 * add a helper function and make the callback smaller
 * include generated bindigs inside own module, so linter allow are
   valid only there
 * fix lint problems in pool.rs
