### PR TITLE
(fix): dedup the results (gh #26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "cnf"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cnf"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.77.0"
 


### PR DESCRIPTION
There can be multiarch repositories with incompatible solvables, like
x86_64/aarch64). Those are excluded by is_installable helper added in
d365524e. But there are other cases like x86_64/i686 or all 32bit arms.

To make the `cnf` output prettier, remove the duplicates before
printing out.
