### PR TITLE
Various documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | **`zsh` integration**              | Yes               | Yes                           |
 | **Disable integration**            | Uninstall package | Magic variable                |
 | **Localization**                   | Yes (UTF-8 only)  | Yes                           |
+| **Package Managers Queried**       | Dnf5, Zypper      | Zypper                        |
 
 ## **Build**
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@
 
 ## **Differences**
 
-|                                    | **`cnf`**         | **`scout(cnf)`**              |
-|------------------------------------|-------------------|-------------------------------|
-| **Uses**                           | `libsolv`         | `libsolv`                     |
-| **Written in**                     | Rust              | Shell, two packages in Python |
-| **Detect enabled/disabled repos?** | Yes               | Yes                           |
-| **Tries to refresh repos**         | No                | Yes                           |
-| **`bash` integration**             | Yes               | Yes                           |
-| **`zsh` integration**              | Yes               | Yes                           |
-| **Disable integration**            | Uninstall package | Magic variable                |
-| **Localization**                   | Yes (UTF-8 only)  | Yes                           |
-| **Package Managers Queried**       | Dnf5, Zypper      | Zypper                        |
+|                                    | **`cnf`**                 | **`scout(cnf)`**              |
+|------------------------------------|---------------------------|-------------------------------|
+| **Uses**                           | `libsolv`                 | `libsolv`                     |
+| **Written in**                     | Rust                      | Shell, two packages in Python |
+| **Detect enabled/disabled repos?** | Yes                       | Yes                           |
+| **Tries to refresh repos**         | No                        | Yes                           |
+| **`bash` integration**             | Yes                       | Yes                           |
+| **`zsh` integration**              | Yes                       | Yes                           |
+| **`fish` integration**             | Included with fish 1.23.1 | Included with fish 1.23.1     |
+| **Disable integration**            | Uninstall package         | Magic variable                |
+| **Localization**                   | Yes (UTF-8 only)          | Yes                           |
+| **Package Managers Queried**       | Dnf5, Zypper              | Zypper                        |
 
 ## **Build**
 
@@ -58,10 +59,10 @@ To query installed programs in `/usr/bin`:
 > Absolute path to 'vim' is '/usr/bin/vim'. Please check your $PATH variable to see whether it contains the mentioned path
 > ```
 
-##  **Integrate with `bash` and `zsh`**
+##  **Integrate with `bash`, `zsh`, and `fish`**
 
 ```.sh
-source command_not_found.bash # or command_not_found.zsh
+source command_not_found.bash # or command_not_found.zsh, or command_not_found.fish
 export COMMAND_NOT_FOUND_BIN=./target/debug/cnf
 cmake
 ```

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To query not installed programs:
 ```
 > ```.log
 > The program 'cmake' can be found in following packages:
->   * cmake-full [ path: /usr/bin/cmake, repository: zypp (repo-oss) ]
->   * cmake-mini [ path: /usr/bin/cmake, repository: zypp (repo-oss) ]
+>   * cmake-full [ path: /usr/bin/cmake, repository: repo-oss ]
+>   * cmake-mini [ path: /usr/bin/cmake, repository: repo-oss ]
 > 
 > Try installing with:
 >     sudo zypper install <selected_package>
@@ -66,8 +66,8 @@ cmake
 ```
 > ```.log
 > The program 'cmake' can be found in following packages:
->   * cmake-full [ path: /usr/bin/cmake, repository: zypp (repo-oss) ]
->   * cmake-mini [ path: /usr/bin/cmake, repository: zypp (repo-oss) ]
+>   * cmake-full [ path: /usr/bin/cmake, repository: repo-oss ]
+>   * cmake-mini [ path: /usr/bin/cmake, repository: repo-oss ]
 > 
 > Try installing with:
 >     sudo zypper install <selected_package>
@@ -85,13 +85,19 @@ The testing itself is wrapped in [bats](https://github.com/bats-core/bats-core) 
 > ```.log
 > test.bats
 >  ✓ root: installed /usr/bin/rpm
->  ✓ root: installed /usr/sbin/sysctl
->  ✓ root: not installed single package
->  ✓ root: not installed more packages
->  ✓ root: bash handler: not installed more packages
->  ✓ nonroot: not installed more packages
-> 
-> 6 tests, 0 failures
+> >  ✓ root: installed /usr/sbin/sysctl
+>  ✓ root: not installed xnake
+>  ✓ root: not installed make
+>  ✓ root: not installed cmake
+>  ✓ nonroot: not installed cmake
+>  ✓ nonroot: bash without handler: not installed cmake
+>  ✓ nonroot: bash handler: not installed cmake
+>  ✓ nonroot: zsh without handler: not installed cmake
+>  ✓ nonroot: zsh handler: not installed cmake
+>  ✓ nonroot: fish handler: not installed cmake
+>  ✓ issue26: do not list not installable files
+>
+> 12 tests, 0 failures
 > ```
 
 Every test can be executed on a command line. The `root.sh` wrapper mounts the

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ To query installed programs in `/usr/bin`:
 > Absolute path to 'vim' is '/usr/bin/vim'. Please check your $PATH variable to see whether it contains the mentioned path
 > ```
 
-##  **Integrate with `bash`**
+##  **Integrate with `bash` and `zsh`**
 
 ```.sh
-source command_not_found_bash
+source command_not_found.bash # or command_not_found.zsh
 export COMMAND_NOT_FOUND_BIN=./target/debug/cnf
 cmake
 ```

--- a/cnf.1
+++ b/cnf.1
@@ -16,8 +16,8 @@ packages. Simply typing missing command executes the handler.
 cmake
 
 The program 'cmake' can be found in following packages:
-  * cmake-full [ path: /usr/bin/cmake, repository: zypp (repo-oss) ]
-  * cmake-mini [ path: /usr/bin/cmake, repository: zypp (repo-oss) ]
+  * cmake-full [ path: /usr/bin/cmake, repository: repo-oss ]
+  * cmake-mini [ path: /usr/bin/cmake, repository: repo-oss ]
 
 Try installing with:
     sudo zypper install <selected_package>

--- a/cnf.1
+++ b/cnf.1
@@ -9,6 +9,9 @@ cnf \- A command not found handler for openSUSE
 libsolv(3) under the hood. The source of truth of information about
 repositories, packages and their content.
 .PP
+This works with enabled dnf5 or zypper repostiores: the first one found in /usr/bin will be used.
+Use dnf5 \-\-refresh makecache or zypper \-\-force refresh to update the metadata used.
+.PP
 It is typically called through command-not-found mechanism of bash(1) or zsh(1)
 or fish(1). This is enabled via installing the cnf-bash or cnf-zsh
 packages. Simply typing missing command executes the handler.

--- a/command_not_found.fish
+++ b/command_not_found.fish
@@ -1,0 +1,7 @@
+function fish_command_not_found
+    if test -z "$COMMAND_NOT_FOUND_BIN"
+        set -l COMMAND_NOT_FOUND_BIN /usr/bin/cnf
+    end
+    # The 'env' is there in case your fish is older than v3.0.0
+    env $COMMAND_NOT_FOUND_BIN $argv[1]
+end

--- a/command_not_found.zsh
+++ b/command_not_found.zsh
@@ -5,10 +5,11 @@
 #  - one to be generic command_not_found_handler() and to be hooked
 #  - one to be available when command_not_found_handler() is redefined
 function command_not_found_handler cnf_handler {
-    if [ -x /usr/bin/cnf ]; then
+    local cnf_bin=${COMMAND_NOT_FOUND_BIN:-/usr/bin/cnf}
+    if [ -x $cnf_bin ]; then
         # take first parameter and remove quotes if there were any so
         # $ 'foo'
         # will search for foo
-        /usr/bin/cnf "${(Q)1}"
+        $cnf_bin "${(Q)1}"
     fi
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,9 @@ mod pool;
 
 const ZYPPER_REPO_GLOB: &str = "/etc/zypp/repos.d/*.repo";
 // Default value of the reposdir configuration directory
-const DNF5_REPOS_GLOBS: [&str; 3] = [
+// (Note that /etc/dnf/repos.d is patched in by the openSUSE dnf5 package)
+const DNF5_REPOS_GLOBS: [&str; 4] = [
+    "/etc/dnf/repos.d/*.repo",
     "/etc/yum.repos.d/*.repo",
     "/etc/distro.repos.d/*.repo",
     "/usr/share/dnf5/repos.d/*.repo",

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,11 @@ fn main() {
     let pm = if Path::exists(Path::new("/usr/bin/dnf5")) {
         // Use DNF5 if it's installed (this should probably be set via a config file, in case you have both installed but prefer zypper)
         PackageManager::Dnf5
-    } else {
+    } else if Path::exists(Path::new("/usr/bin/zypper")) {
         PackageManager::Zypper
+    } else {
+        println!("Neither /usr/bin/dnf5 nor /usr/bin/zypper could be found.");
+        exit(127);
     };
 
     let repos = match load_repos(pm) {


### PR DESCRIPTION
This makes a few changes to the documentation, reflecting the changes made by dnf5 (#32).
Commit ab4cd24b351a8d070da4903a928ae6333f84b0a4 is overkill, but is necessary if you want to use a `cnf` that is not available in your path as "command-not-found". In particular, together with df878e8aeff9731dae2fc7ebe443aa6e5f705007, the Readme instructions now show how to use your manually built `cnf` with `bash`, `zsh`, and `fish` (the only difference being which file to `source`).

To avoid merge conflicts, this pull request assumes the previous one (#34), but it's mostly independent. So please ignore the first two listed commits.