### PR TITLE
Dnf4 Support

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -63,6 +63,17 @@ jobs:
           push: false
           tags: local/cnf-ci-zypper:latest
       -
+        name: Build openSUSE Tumbleweed image with dnf4
+        uses: docker/build-push-action@v4
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: test/
+          file: test/dnf.dockerfile
+          load: true
+          push: false
+          tags: local/cnf-ci-dnf:latest
+      -
         name: Build openSUSE Tumbleweed image with dnf5
         uses: docker/build-push-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ cmake
 
 ## **Integration tests**
 
-Integration tests runs inside docker images tagged `local/cnf-ci-zypper` and `local/cnf-ci-dnf5`. these are built as a part of Github Action and can be built locally with:
+Integration tests runs inside docker images tagged `local/cnf-ci-zypper`, `local/cnf-ci-dnf`, and `local/cnf-ci-dnf5`. these are built as a part of Github Action and can be built locally with:
 
 ```.sh
-for pm in zypper dnf5; do
+for pm in zypper dnf dnf5; do
     docker build -t local/cnf-ci-$pm:latest -f test/$pm.dockerfile test
 done
 ```
@@ -91,7 +91,6 @@ The testing itself is wrapped in [bats](https://github.com/bats-core/bats-core) 
 ./test/bats/bin/bats ./test/
 ```
 > ```.log
-> test.bats
 >  ✓ zypper root: installed /usr/bin/rpm
 >  ✓ zypper root: installed /usr/sbin/sysctl
 >  ✓ zypper root: not installed xnake
@@ -104,6 +103,18 @@ The testing itself is wrapped in [bats](https://github.com/bats-core/bats-core) 
 >  ✓ zypper nonroot: zsh handler: not installed cmake
 >  ✓ zypper nonroot: fish handler: not installed cmake
 >  ✓ zypper issue26: do not list not installable files
+>  ✓ dnf root: installed /usr/bin/rpm
+>  ✓ dnf root: installed /usr/sbin/sysctl
+>  ✓ dnf root: not installed xnake
+>  ✓ dnf root: not installed make
+>  ✓ dnf root: not installed cmake
+>  ✓ dnf nonroot: not installed cmake
+>  ✓ dnf nonroot: bash without handler: not installed cmake
+>  ✓ dnf nonroot: bash handler: not installed cmake
+>  ✓ dnf nonroot: zsh without handler: not installed cmake
+>  ✓ dnf nonroot: zsh handler: not installed cmake
+>  ✓ dnf nonroot: fish handler: not installed cmake
+>  ✓ dnf issue26: do not list not installable files
 >  ✓ dnf5 root: installed /usr/bin/rpm
 >  ✓ dnf5 root: installed /usr/sbin/sysctl
 >  ✓ dnf5 root: not installed xnake
@@ -117,7 +128,7 @@ The testing itself is wrapped in [bats](https://github.com/bats-core/bats-core) 
 >  ✓ dnf5 nonroot: fish handler: not installed cmake
 >  ✓ dnf5 issue26: do not list not installable files
 > 
-> 24 tests, 0 failures
+> 36 tests, 0 failures
 > ```
 
 Every test can be executed on a command line. The `root.sh` wrapper mounts the

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | **`fish` integration**             | Included with fish 1.23.1 | Included with fish 1.23.1     |
 | **Disable integration**            | Uninstall package         | Magic variable                |
 | **Localization**                   | Yes (UTF-8 only)          | Yes                           |
-| **Package Managers Queried**       | Dnf5, Zypper              | Zypper                        |
+| **Package Managers Queried**       | Dnf5, Dnf4, Zypper        | Zypper                        |
 
 ## **Build**
 

--- a/cnf.1
+++ b/cnf.1
@@ -9,8 +9,8 @@ cnf \- A command not found handler for openSUSE
 libsolv(3) under the hood. The source of truth of information about
 repositories, packages and their content.
 .PP
-This works with enabled dnf5 or zypper repostiores: the first one found in /usr/bin will be used.
-Use dnf5 \-\-refresh makecache or zypper \-\-force refresh to update the metadata used.
+This works with enabled dnf5, dnf, or zypper repostiores: the first one found in /usr/bin will be used.
+Use dnf5 \-\-refresh makecache, dnf \-\-refresh makecache, or zypper \-\-force refresh to update the metadata used.
 .PP
 It is typically called through command-not-found mechanism of bash(1) or zsh(1)
 or fish(1). This is enabled via installing the cnf-bash or cnf-zsh

--- a/test/dnf.dockerfile
+++ b/test/dnf.dockerfile
@@ -1,0 +1,21 @@
+# Tumbleweed based CI image for cnf integration testing with dnf4
+FROM registry.opensuse.org/opensuse/tumbleweed
+
+# This is the same as dnf5.dockerfile
+ADD passwd /etc/passwd
+ADD group /etc/group
+ADD --chown=65532:65532 nonroot /home/nonroot/whoami
+
+# The following is exactly the same as for dnf5, except it uses 'dnf' instead of 'dnf5'
+RUN zypper refresh
+# As with dnf5, dnf4 fails to work without the libcurl4 package
+RUN zypper --non-interactive install --no-recommends dnf libcurl4 rpm-repos-openSUSE-Tumbleweed
+RUN dnf --assumeyes remove zypper libzypp
+RUN rm -rf /etc/zypp /var/cache/zypp/ /var/lib/zypp
+
+RUN echo excludepkgs=busybox dbus diffutils pam-config perl-base systemd groff man >> /etc/dnf/dnf.conf
+RUN dnf --setopt install_weak_deps=False --assumeyes install zsh fish libsolv1
+RUN curl -O https://download.opensuse.org/repositories/GNOME:/Next/openSUSE_Factory/GNOME:Next.repo --output-dir /etc/dnf/repos.d/
+RUN dnf makecache
+
+WORKDIR /src

--- a/test/test.bats
+++ b/test/test.bats
@@ -21,7 +21,7 @@ function make_test {
     bats_test_function --description "$1" -- "$name"
 }
 
-for PM in zypper dnf5; do
+for PM in zypper dnf dnf5; do
 
 make_test "$PM root: installed /usr/bin/rpm" <<EOF
     run root.sh $PM '/usr/bin/cnf' 'rpm'


### PR DESCRIPTION
I don't know why I bothered with this (is there any reason to use `dnf` over `dnf5`, even when running the simply test cases it's noticibly slower), but since `dnf` v4 is in the openSUSE Tumbleweed repositories, I felt like `cnf` was incomplete without it.

Note that the docker image for dnf4 could trivially be generated by:
```
sed -i 's/dnf5/dnf/g' dnf5.dockerfile > dnf.dockerfile
```
The changes to he rust code are a little less trivial as `dnf` uses different folders for the `.repo` and `solv` files.

This relies on various changes made by my previous pull requests (#34, #35, and #36), only the last 3 commits are new.
Hopefully this will be my last pull request.